### PR TITLE
remove nodejs buildpack to test

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,9 +1,6 @@
 {
   "buildpacks": [
     {
-      "url": "heroku/nodejs"
-    },
-    {
       "url": "mars/create-react-app"
     }
   ]


### PR DESCRIPTION
### Why this change is needed
testing to see if it works without node buildpack, as create-react-app should account for nodejs anyway 

###  Changes made
removed nodejs from app.js

### How this change was tested

